### PR TITLE
Add a Stopwatch class and replace usages of itk::TimeProbe

### DIFF
--- a/Examples/Classification/ClassificationMapRegularizationExample.cxx
+++ b/Examples/Classification/ClassificationMapRegularizationExample.cxx
@@ -46,8 +46,6 @@
 #include <otbImageFileReader.h>
 #include "otbImageFileWriter.h"
 
-#include "itkTimeProbe.h"
-
 
 int main(int itkNotUsed(argc), char * argv[])
 {

--- a/Modules/Adapters/GdalAdapters/src/otbGeometriesToGeometriesFilter.cxx
+++ b/Modules/Adapters/GdalAdapters/src/otbGeometriesToGeometriesFilter.cxx
@@ -25,7 +25,7 @@
 #include "otbGeometriesToGeometriesFilter.h"
 #include <cassert>
 #include "otbGeometriesSet.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "otbMacro.h"
 
 /*===========================================================================*/
@@ -200,8 +200,7 @@ void otb::GeometriesToGeometriesFilter::GenerateData(void )
   assert(output && "Cann't filter a nil geometries set");
 
   // Start recursive processing
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   if (input)
     {
     this->Process(*input, *output);
@@ -212,7 +211,7 @@ void otb::GeometriesToGeometriesFilter::GenerateData(void )
     }
 
   chrono.Stop();
-  otbMsgDevMacro(<< "GeometriesToGeometriesFilter: geometries processed in " << chrono.GetMean() << " seconds.");
+  otbMsgDevMacro(<< "GeometriesToGeometriesFilter: geometries processed in " << chrono.GetElapsedMilliseconds() << " ms.");
 }
 
 /*virtual*/

--- a/Modules/Applications/AppClassification/app/otbTrainRegression.cxx
+++ b/Modules/Applications/AppClassification/app/otbTrainRegression.cxx
@@ -29,7 +29,6 @@
 // Statistic XML Reader
 #include "otbStatisticsXMLFileReader.h"
 
-#include "itkTimeProbe.h"
 #include "otbStandardFilterWatcher.h"
 
 // Normalize the samples

--- a/Modules/Applications/AppImageUtils/app/otbConvert.cxx
+++ b/Modules/Applications/AppImageUtils/app/otbConvert.cxx
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <numeric>
+
 #include "otbWrapperApplication.h"
 #include "otbWrapperApplicationFactory.h"
 
@@ -196,7 +198,7 @@ private:
     if ( HasValue("in") )
       {
       typedef otb::ImageMetadataInterfaceBase ImageMetadataInterfaceType;
-      ImageMetadataInterfaceType::Pointer metadataInterface = 
+      ImageMetadataInterfaceType::Pointer metadataInterface =
       ImageMetadataInterfaceFactory::CreateIMI(GetParameterImage("in")->GetMetaDataDictionary());
 
       int nbBand = GetParameterImage("in")->GetNumberOfComponentsPerPixel();
@@ -216,7 +218,7 @@ private:
         SetDefaultParameterInt("channels.rgb.blue", bandBlue);
         }
       }
-    
+
 
   }
 

--- a/Modules/Applications/AppMoments/app/otbLocalStatisticExtraction.cxx
+++ b/Modules/Applications/AppMoments/app/otbLocalStatisticExtraction.cxx
@@ -26,8 +26,6 @@
 
 #include "otbMultiToMonoChannelExtractROI.h"
 
-#include "itkTimeProbe.h"
-
 namespace otb
 {
 namespace Wrapper

--- a/Modules/Applications/AppMorphology/app/otbBinaryMorphologicalOperation.cxx
+++ b/Modules/Applications/AppMorphology/app/otbBinaryMorphologicalOperation.cxx
@@ -34,8 +34,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
-
 namespace otb
 {
 namespace Wrapper

--- a/Modules/Applications/AppMorphology/app/otbGrayScaleMorphologicalOperation.cxx
+++ b/Modules/Applications/AppMorphology/app/otbGrayScaleMorphologicalOperation.cxx
@@ -34,8 +34,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
-
 namespace otb
 {
 namespace Wrapper

--- a/Modules/Applications/AppMorphology/app/otbMorphologicalClassification.cxx
+++ b/Modules/Applications/AppMorphology/app/otbMorphologicalClassification.cxx
@@ -35,7 +35,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
 #include "otbConvexOrConcaveClassificationFilter.h"
 #include "otbMorphologicalProfilesSegmentationFilter.h"
 

--- a/Modules/Applications/AppMorphology/app/otbMorphologicalMultiScaleDecomposition.cxx
+++ b/Modules/Applications/AppMorphology/app/otbMorphologicalMultiScaleDecomposition.cxx
@@ -35,7 +35,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
 #include "otbConvexOrConcaveClassificationFilter.h"
 #include "otbMorphologicalProfilesSegmentationFilter.h"
 #include "otbGeodesicMorphologyIterativeDecompositionImageFilter.h"

--- a/Modules/Applications/AppMorphology/app/otbMorphologicalProfilesAnalysis.cxx
+++ b/Modules/Applications/AppMorphology/app/otbMorphologicalProfilesAnalysis.cxx
@@ -36,7 +36,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
 #include "otbConvexOrConcaveClassificationFilter.h"
 #include "otbMorphologicalProfilesSegmentationFilter.h"
 #include "otbGeodesicMorphologyIterativeDecompositionImageFilter.h"

--- a/Modules/Applications/AppTextures/app/otbSFSTextureExtraction.cxx
+++ b/Modules/Applications/AppTextures/app/otbSFSTextureExtraction.cxx
@@ -28,8 +28,6 @@
 #include "otbImageList.h"
 #include "otbImageListToVectorImageFilter.h"
 
-#include "itkTimeProbe.h"
-
 namespace otb
 {
 namespace Wrapper

--- a/Modules/Core/Common/include/otbFilterWatcherBase.h
+++ b/Modules/Core/Common/include/otbFilterWatcherBase.h
@@ -22,9 +22,9 @@
 #ifndef otbFilterWatcherBase_h
 #define otbFilterWatcherBase_h
 
+#include "otbStopwatch.h"
 #include "itkCommand.h"
 #include "itkProcessObject.h"
-#include "itkTimeProbe.h"
 
 #include "OTBCommonExport.h"
 
@@ -82,10 +82,10 @@ public:
     return m_Comment;
   }
 
-  /** Get a reference to the TimeProbe */
-  itk::TimeProbe& GetTimeProbe()
+  /** Get a reference to the Stopwatch */
+  otb::Stopwatch& GetStopwatch()
   {
-    return m_TimeProbe;
+    return m_Stopwatch;
   }
 
 protected:
@@ -126,7 +126,7 @@ protected:
   virtual void EndFilter() = 0;
 
   /** Computing time */
-  itk::TimeProbe m_TimeProbe;
+  otb::Stopwatch m_Stopwatch;
 
   /** Associated comment */
   std::string m_Comment;

--- a/Modules/Core/Common/include/otbStopwatch.h
+++ b/Modules/Core/Common/include/otbStopwatch.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2005-2017 Centre National d'Etudes Spatiales (CNES)
+ *
+ * This file is part of Orfeo Toolbox
+ *
+ *     https://www.orfeo-toolbox.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef otbStopwatch_h
+#define otbStopwatch_h
+
+#include <cstdint>
+
+#include "OTBCommonExport.h"
+
+namespace otb
+{
+
+/** \class Stopwatch
+ * \brief Stopwatch timer.
+ *
+ * A simple class for measuring elapsed time.
+ *
+ *
+ * \ingroup OTBCommon
+ */
+class OTBCommon_EXPORT Stopwatch final
+{
+public:
+  /** Standard class typedefs. */
+  typedef Stopwatch  Self;
+
+  /** Represents a duration measured in milliseconds */
+  typedef uint64_t   DurationType;
+
+  /** Constructs a timer instance */
+  Stopwatch();
+
+  /** Start the timer if not already running */
+  void Start();
+
+  /** Stop the timer if running */
+  void Stop();
+
+  /** Reset the timer */
+  void Reset();
+
+  /** Reset and restart the timer */
+  void Restart();
+
+  /** Get the total duration, excluding the current iteration */
+  DurationType GetElapsedMilliseconds() const;
+
+  /** Returns whether the stopwatch is running */
+  bool IsRunning() const;
+
+  /** Creates and starts a new stopwatch instance */
+  static Stopwatch StartNew();
+
+private:
+  typedef uint64_t   TimepointType;
+
+  TimepointType GetTimestamp() const;
+  DurationType GetRunningElapsedTime() const;
+
+  TimepointType m_StartTime;
+  DurationType m_ElapsedMilliseconds;
+  bool m_IsRunning;
+};
+
+} // namespace otb
+
+#endif

--- a/Modules/Core/Common/include/otbWriterWatcherBase.h
+++ b/Modules/Core/Common/include/otbWriterWatcherBase.h
@@ -22,9 +22,10 @@
 #ifndef otbWriterWatcherBase_h
 #define otbWriterWatcherBase_h
 
+#include "otbStopwatch.h"
+
 #include "itkCommand.h"
 #include "itkProcessObject.h"
-#include "itkTimeProbe.h"
 
 #include "OTBCommonExport.h"
 
@@ -89,10 +90,10 @@ public:
     return m_Comment;
   }
 
-  /** Get a reference to the TimeProbe */
-  itk::TimeProbe& GetTimeProbe()
+  /** Get a reference to the Stopwatch */
+  otb::Stopwatch& GetStopwatch()
   {
-    return m_TimeProbe;
+    return m_Stopwatch;
   }
 
 protected:
@@ -116,7 +117,7 @@ protected:
   virtual void EndFilter() = 0;
 
   /** Computing time */
-  itk::TimeProbe m_TimeProbe;
+  otb::Stopwatch m_Stopwatch;
 
   /** Associated comment */
   std::string m_Comment;

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -27,10 +27,11 @@ set(OTBCommon_SRC
   otbConfigurationManager.cxx
   otbStandardOneLineFilterWatcher.cxx
   otbWriterWatcherBase.cxx
+  otbStopwatch.cxx
   )
 
 add_library(OTBCommon ${OTBCommon_SRC})
-target_link_libraries(OTBCommon 
+target_link_libraries(OTBCommon
   ${OTBITK_LIBRARIES}
 
   )

--- a/Modules/Core/Common/src/otbFilterWatcherBase.cxx
+++ b/Modules/Core/Common/src/otbFilterWatcherBase.cxx
@@ -81,7 +81,7 @@ FilterWatcherBase
     }
 
   // Initialize state
-  m_TimeProbe = watch.m_TimeProbe;
+  m_Stopwatch = watch.m_Stopwatch;
   m_Process = watch.m_Process;
   m_Comment = watch.m_Comment;
 
@@ -125,7 +125,7 @@ FilterWatcherBase
     }
 
   // Initialize state
-  m_TimeProbe = watch.m_TimeProbe;
+  m_Stopwatch = watch.m_Stopwatch;
   m_Process = watch.m_Process;
   m_Comment = watch.m_Comment;
 

--- a/Modules/Core/Common/src/otbStandardFilterWatcher.cxx
+++ b/Modules/Core/Common/src/otbStandardFilterWatcher.cxx
@@ -100,7 +100,7 @@ void
 StandardFilterWatcher
 ::StartFilter()
 {
-  m_TimeProbe.Start();
+  m_Stopwatch.Start();
   std::cout << (m_Process.GetPointer() ? m_Process->GetNameOfClass() : "None")
             << " \"" << m_Comment << "\" " << std::endl;
 }
@@ -109,9 +109,9 @@ void
 StandardFilterWatcher
 ::EndFilter()
 {
-  m_TimeProbe.Stop();
+  m_Stopwatch.Stop();
   std::cout << std::endl << "Filter took "
-            << m_TimeProbe.GetMean()
+            << m_Stopwatch.GetElapsedMilliseconds() / 1000
             << " seconds." << std::endl;
 }
 } // end namespace otb

--- a/Modules/Core/Common/src/otbStandardOneLineFilterWatcher.cxx
+++ b/Modules/Core/Common/src/otbStandardOneLineFilterWatcher.cxx
@@ -94,19 +94,19 @@ void
 StandardOneLineFilterWatcher
 ::StartFilter()
 {
-  m_TimeProbe.Start();
+  m_Stopwatch.Start();
 }
 
 void
 StandardOneLineFilterWatcher
 ::EndFilter()
 {
-  m_TimeProbe.Stop();
+  m_Stopwatch.Stop();
 
   // Ensure we don't depend on std::cout configuration
   std::ostringstream elapsedTime;
   elapsedTime.precision(1);
-  elapsedTime << m_TimeProbe.GetMean();
+  elapsedTime << m_Stopwatch.GetElapsedMilliseconds() / 1000;
 
   std::cout << " ("
             << elapsedTime.str()

--- a/Modules/Core/Common/src/otbStandardWriterWatcher.cxx
+++ b/Modules/Core/Common/src/otbStandardWriterWatcher.cxx
@@ -147,7 +147,7 @@ void
 StandardWriterWatcher
 ::StartWriter()
 {
-  m_TimeProbe.Start();
+  m_Stopwatch.Start();
   std::cout << "Writing task: " << " \"" << m_Comment << "\" " << std::endl;
   std::cout << "Writer type: " << (m_Process.GetPointer() ? m_Process->GetNameOfClass() : "None") << std::endl;
   std::cout << "Filter type: " << (m_SourceProcess.GetPointer() ? m_SourceProcess->GetNameOfClass() : "None") <<
@@ -158,9 +158,9 @@ void
 StandardWriterWatcher
 ::EndWriter()
 {
-  m_TimeProbe.Stop();
+  m_Stopwatch.Stop();
   std::cout << std::endl << "Writing task took "
-            << m_TimeProbe.GetMean()
+            << m_Stopwatch.GetElapsedMilliseconds() / 1000
             << " seconds." << std::endl;
 }
 

--- a/Modules/Core/Common/src/otbStopwatch.cxx
+++ b/Modules/Core/Common/src/otbStopwatch.cxx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2005-2017 Centre National d'Etudes Spatiales (CNES)
+ *
+ * This file is part of Orfeo Toolbox
+ *
+ *     https://www.orfeo-toolbox.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+
+#include "otbStopwatch.h"
+
+namespace otb
+{
+
+Stopwatch
+::Stopwatch()
+    : m_ElapsedMilliseconds(), m_IsRunning()
+{
+}
+
+void
+Stopwatch
+::Start()
+{
+  if (!this->m_IsRunning)
+    {
+    this->m_IsRunning = true;
+    this->m_StartTime = this->GetTimestamp();
+    }
+}
+
+void
+Stopwatch
+::Stop()
+{
+  if (this->m_IsRunning)
+    {
+    this->m_ElapsedMilliseconds += GetRunningElapsedTime();
+    this->m_IsRunning = false;
+    }
+}
+
+void
+Stopwatch
+::Reset()
+{
+  this->m_ElapsedMilliseconds = 0;
+  this->m_IsRunning = false;
+}
+
+void
+Stopwatch
+::Restart()
+{
+  this->m_ElapsedMilliseconds = 0;
+  this->m_IsRunning = true;
+  this->m_StartTime = this->GetTimestamp();
+}
+
+Stopwatch::DurationType
+Stopwatch
+::GetElapsedMilliseconds() const
+{
+  auto result = this->m_ElapsedMilliseconds;
+
+  if (this->m_IsRunning)
+    result += this->GetRunningElapsedTime();
+
+  return result;
+}
+
+bool
+Stopwatch
+::IsRunning() const
+{
+  return this->m_IsRunning;
+}
+
+Stopwatch
+Stopwatch
+::StartNew()
+{
+  Stopwatch sw;
+  sw.Start();
+
+  return sw;
+}
+
+inline
+Stopwatch::TimepointType
+Stopwatch
+::GetTimestamp() const
+{
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+}
+
+inline
+Stopwatch::DurationType
+Stopwatch
+::GetRunningElapsedTime() const
+{
+  return this->GetTimestamp() - this->m_StartTime;
+}
+
+}

--- a/Modules/Core/Common/src/otbWriterWatcherBase.cxx
+++ b/Modules/Core/Common/src/otbWriterWatcherBase.cxx
@@ -188,7 +188,7 @@ WriterWatcherBase
     }
 
   // Initialize state
-  m_TimeProbe = watch.m_TimeProbe;
+  m_Stopwatch = watch.m_Stopwatch;
   m_Process = watch.m_Process;
   m_SourceProcess = watch.m_SourceProcess;
   m_Comment = watch.m_Comment;
@@ -281,7 +281,7 @@ WriterWatcherBase
     }
 
   // Initialize state
-  m_TimeProbe = watch.m_TimeProbe;
+  m_Stopwatch = watch.m_Stopwatch;
   m_Process = watch.m_Process;
   m_SourceProcess = watch.m_SourceProcess;
   m_Comment = watch.m_Comment;

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -37,6 +37,7 @@ otbConfigurationManagerTest.cxx
 otbStandardFilterWatcherNew.cxx
 otbStandardOneLineFilterWatcherTest.cxx
 otbStandardWriterWatcher.cxx
+otbStopwatchTest.cxx
 )
 
 add_executable(otbCommonTestDriver ${OTBCommonTests})
@@ -166,6 +167,9 @@ otb_add_test(NAME coTuSystemTests_IsA_Methods COMMAND otbCommonTestDriver
   ${OTB_DATA_ROOT}/README-OTB-Data
   ${OTB_DATA_ROOT}
   )
+
+otb_add_test(NAME coTuStopwatchTests COMMAND otbCommonTestDriver
+  otbStopwatchTest)
 
 otb_add_test(NAME coTvParseHdfSubsetName COMMAND otbCommonTestDriver
   otbParseHdfSubsetName)

--- a/Modules/Core/Common/test/otbCommonTestDriver.cxx
+++ b/Modules/Core/Common/test/otbCommonTestDriver.cxx
@@ -31,6 +31,7 @@ void RegisterTests()
   REGISTER_TEST(otbRectangle);
   REGISTER_TEST(otbImageRegionNonUniformMultidimensionalSplitterNew);
   REGISTER_TEST(otbSystemTest);
+  REGISTER_TEST(otbStopwatchTest);
   REGISTER_TEST(otbParseHdfSubsetName);
   REGISTER_TEST(otbParseHdfFileName);
   REGISTER_TEST(otbImageRegionSquareTileSplitterNew);

--- a/Modules/Core/Common/test/otbStopwatchTest.cxx
+++ b/Modules/Core/Common/test/otbStopwatchTest.cxx
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2005-2017 Centre National d'Etudes Spatiales (CNES)
+ *
+ * This file is part of Orfeo Toolbox
+ *
+ *     https://www.orfeo-toolbox.org/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <cassert>
+#include <iostream>
+#include <cstdlib>
+
+#if 0
+#include <unistd.h>
+
+#include "itkTimeProbe.h"
+#endif
+
+#include "itkMacro.h"
+#include "otbStopwatch.h"
+
+int otbStopwatchTest(int itkNotUsed(argc), char * itkNotUsed(argv)[])
+{
+  otb::Stopwatch sw;
+
+  assert( !sw.IsRunning() );
+  assert( sw.GetElapsedMilliseconds() == 0 );
+
+  sw.Start();
+  assert( sw.IsRunning() );
+  sw.Stop();
+
+  sw.Reset();
+  assert( !sw.IsRunning() );
+  assert( sw.GetElapsedMilliseconds() == 0 );
+
+  sw = otb::Stopwatch::StartNew();
+  assert( sw.IsRunning() );
+  sw.Stop();
+
+#if 0
+  // We have no portable sleep() and otbThreads is not linked here
+  sw.Start();
+  usleep(500 * 1000);
+  sw.Stop();
+  assert( sw.GetElapsedMilliseconds() > 450 && sw.GetElapsedMilliseconds() < 550 );
+
+  sw.Start();
+  usleep(500 * 1000);
+  sw.Stop();
+  assert( sw.GetElapsedMilliseconds() > 900 && sw.GetElapsedMilliseconds() < 1100 );
+
+  sw.Restart();
+  usleep(500 * 1000);
+  sw.Stop();
+  assert( sw.GetElapsedMilliseconds() > 450 && sw.GetElapsedMilliseconds() < 550 );
+
+  const int iterations = 100000;
+  sw.Restart();
+  for (int i = 0; i < iterations; i++)
+    {
+    itk::TimeProbe chrono;
+    chrono.Start();
+    chrono.Stop();
+    }
+  std::cerr << "itk::TimeProbe time: " << sw.GetElapsedMilliseconds() << std::endl;
+
+  sw.Restart();
+  for (int i = 0; i < iterations; i++)
+    {
+    auto chrono = otb::Stopwatch::StartNew();
+    chrono.Stop();
+    }
+  std::cerr << "otb::Stopwatch time: " << sw.GetElapsedMilliseconds() << std::endl;
+
+  #endif
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Core/ImageBase/test/otbMultiChannelExtractROI.cxx
+++ b/Modules/Core/ImageBase/test/otbMultiChannelExtractROI.cxx
@@ -26,7 +26,7 @@
 
 #include "otbImage.h"
 
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 
 template <typename  InputPixelType /*= unsigned char */, typename OutputPixelType /*= unsigned char*/>
@@ -130,20 +130,11 @@ int generic_otbMultiChannelExtractROI(int itkNotUsed(argc), char * argv[], const
 
   writer->SetInput(extractROIFilter->GetOutput());
 
-  itk::TimeProbe chrono;
-
-  if (computeExtractTime)
-  {
-         chrono.Start();
-  }
-
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   writer->Update();
 
   if (computeExtractTime)
-  {
-         chrono.Stop();
-         std::cout << " Time to compute the extracted image: " << chrono.GetTotal() << " seconds" << std::endl;
-  }
+    std::cout << " Time to compute the extracted image: " << chrono.GetElapsedMilliseconds() << " ms" << std::endl;
 
   std::cout << " Number of channels in the input image: " << reader->GetOutput()->GetNumberOfComponentsPerPixel() <<
   std::endl;

--- a/Modules/Core/LabelMap/test/otbLabelObjectMapVectorizer.cxx
+++ b/Modules/Core/LabelMap/test/otbLabelObjectMapVectorizer.cxx
@@ -26,7 +26,7 @@
 #include "otbVectorData.h"
 #include "otbVectorDataProjectionFilter.h"
 #include "otbVectorDataFileWriter.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "itkMinimumMaximumImageCalculator.h"
 
 #include "otbCorrectPolygonFunctor.h"
@@ -87,15 +87,13 @@ int otbLabelObjectMapVectorizer(int argc, char * argv[])
   data->GetDataTree()->Add(folder1, document);
   data->SetProjectionRef(lreader->GetOutput()->GetProjectionRef());
 
-  itk::TimeProbe chrono;
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
 
   // If a label is given, extract only this label
   if (argc == 4)
     {
     std::cout << "Label is given; Vectorizing object " << atoi(argv[3]) << std::endl;
-    chrono.Start();
     PolygonType::Pointer polygon = functor(labelMapFilter->GetOutput()->GetLabelObject(atoi(argv[3])));
-    chrono.Stop();
 
     //correct polygon
     PolygonType::Pointer correct_polygon = correctPolygon(polygon);
@@ -117,9 +115,7 @@ int otbLabelObjectMapVectorizer(int argc, char * argv[])
       if (labelMapFilter->GetOutput()->HasLabel(label) && label != labelMapFilter->GetOutput()->GetBackgroundValue())
         {
         std::cout << "Vectorizing object " << label << std::endl;
-        chrono.Start();
         PolygonType::Pointer polygon = functor(labelMapFilter->GetOutput()->GetLabelObject(label));
-        chrono.Stop();
 
         //correct polygon
         PolygonType::Pointer correct_polygon = correctPolygon(polygon);
@@ -131,7 +127,8 @@ int otbLabelObjectMapVectorizer(int argc, char * argv[])
         }
       }
     }
-  std::cout << "Average vectorization time: " << chrono.GetMean() << " s." << std::endl;
+
+  std::cout << "Total vectorization time: " << chrono.GetElapsedMilliseconds() << " ms." << std::endl;
 
   VectorDataFilterType::Pointer vectorDataProjection = VectorDataFilterType::New();
   vectorDataProjection->SetInputOrigin(lreader->GetOutput()->GetOrigin());

--- a/Modules/Filtering/Convolution/test/otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter.cxx
+++ b/Modules/Filtering/Convolution/test/otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter.cxx
@@ -25,11 +25,11 @@
 #include "otbImage.h"
 #include "otbImageFileReader.h"
 #include "otbImageFileWriter.h"
+#include "otbStopwatch.h"
 #include "otbConvolutionImageFilter.h"
 #include "otbOverlapSaveConvolutionImageFilter.h"
 #include "otbGaborFilterGenerator.h"
 #include "itkConstantBoundaryCondition.h"
-#include "itkTimeProbe.h"
 
 int otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter(int argc, char *argv[])
 {
@@ -82,8 +82,6 @@ int otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter(int argc, char *
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(infname);
 
-  itk::TimeProbe probe1, probe2;
-
   ConvolutionFilterType::Pointer convolution = ConvolutionFilterType::New();
   convolution->SetRadius(radius);
   convolution->SetFilter(filter);
@@ -93,11 +91,10 @@ int otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter(int argc, char *
   writer1->SetInput(convolution->GetOutput());
   writer1->SetFileName(outfname1);
 
-  probe1.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   writer1->Update();
-  probe1.Stop();
 
-  std::cout << "Classical convolution algorithm took " << probe1.GetMean() << " seconds." << std::endl;
+  std::cout << "Classical convolution algorithm took " << chrono.GetElapsedMilliseconds() << " ms." << std::endl;
 
   OSConvolutionFilterType::Pointer osconvolution = OSConvolutionFilterType::New();
   osconvolution->SetRadius(radius);
@@ -108,11 +105,10 @@ int otbCompareOverlapSaveAndClassicalConvolutionWithGaborFilter(int argc, char *
   writer2->SetInput(osconvolution->GetOutput());
   writer2->SetFileName(outfname2);
 
-  probe2.Start();
+  chrono.Restart();
   writer2->Update();
-  probe2.Stop();
 
-  std::cout << "Overlap-save convolution algorithm took " << probe2.GetMean() << " seconds." << std::endl;
+  std::cout << "Overlap-save convolution algorithm took " << chrono.GetElapsedMilliseconds() << " ms." << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Filtering/Projection/include/otbVectorDataProjectionFilter.txx
+++ b/Modules/Filtering/Projection/include/otbVectorDataProjectionFilter.txx
@@ -25,7 +25,7 @@
 #include "itkProgressReporter.h"
 #include "itkMetaDataObject.h"
 #include "otbMetaDataKey.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 namespace otb
 {
@@ -358,11 +358,10 @@ VectorDataProjectionFilter<TInputVectorData, TOutputVectorData>
   tree->SetRoot(outputRoot);
 
   // Start recursive processing
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   this->ProcessNode(inputRoot, outputRoot);
   chrono.Stop();
-  otbMsgDevMacro(<< "VectoDataProjectionFilter: features Processed in " << chrono.GetMean() << " seconds.");
+  otbMsgDevMacro(<< "VectoDataProjectionFilter: features processed in " << chrono.GetElapsedMilliseconds() << " ms.");
 }
 
 } // end namespace otb

--- a/Modules/Filtering/Projection/include/otbVectorDataTransformFilter.txx
+++ b/Modules/Filtering/Projection/include/otbVectorDataTransformFilter.txx
@@ -24,7 +24,7 @@
 #include "otbVectorDataTransformFilter.h"
 #include "itkProgressReporter.h"
 #include <itkContinuousIndex.h>
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 namespace otb
 {
@@ -163,10 +163,10 @@ VectorDataTransformFilter<TInputVectorData, TOutputVectorData>
   tree->SetRoot(outputRoot);
 
   // Start recursive processing
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   this->ProcessNode(inputRoot, outputRoot);
   chrono.Stop();
+  otbMsgDevMacro(<< "VectorDataTransformFilter: features processed in " << chrono.GetElapsedMilliseconds() << " ms.");
 }
 
 } // end namespace otb

--- a/Modules/Filtering/VectorDataManipulation/include/otbConcatenateVectorDataFilter.txx
+++ b/Modules/Filtering/VectorDataManipulation/include/otbConcatenateVectorDataFilter.txx
@@ -24,7 +24,6 @@
 #include "otbConcatenateVectorDataFilter.h"
 
 #include "otbMath.h"
-#include "itkTimeProbe.h"
 
 namespace otb
 {

--- a/Modules/Filtering/VectorDataManipulation/include/otbVectorDataExtractROI.txx
+++ b/Modules/Filtering/VectorDataManipulation/include/otbVectorDataExtractROI.txx
@@ -31,7 +31,7 @@
 #include "otbMacro.h"
 
 #include "itkProgressReporter.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 namespace otb
 {
@@ -110,12 +110,11 @@ VectorDataExtractROI<TVectorData>
   m_Kept  = 0;
 
   // Start recursive processing
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   ProcessNode(inputRoot, outputRoot);
   chrono.Stop();
   otbMsgDevMacro(
-    << "VectorDataExtractROI: " << m_Kept << " Features processed in " << chrono.GetMean() << " seconds.");
+    << "VectorDataExtractROI: " << m_Kept << " features processed in " << chrono.GetElapsedMilliseconds() << " ms.");
 } /*End GenerateData()*/
 
 template <class TVectorData>

--- a/Modules/Filtering/VectorDataManipulation/include/otbVectorDataToVectorDataFilter.txx
+++ b/Modules/Filtering/VectorDataManipulation/include/otbVectorDataToVectorDataFilter.txx
@@ -24,7 +24,7 @@
 #include "otbVectorDataToVectorDataFilter.h"
 #include "itkProgressReporter.h"
 #include "otbDataNode.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 namespace otb
 {
@@ -104,11 +104,10 @@ VectorDataToVectorDataFilter<TInputVectorData, TOutputVectorData>
   tree->SetRoot(outputRoot);
 
   // Start recursive processing
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   this->ProcessNode(inputRoot, outputRoot);
   chrono.Stop();
-  otbMsgDevMacro(<< "VectoDataProjectionFilter: features Processed in " << chrono.GetMean() << " seconds.");
+  otbMsgDevMacro(<< "VectoDataProjectionFilter: features processed in " << chrono.GetElapsedMilliseconds() << " ms.");
 }
 
 template <class TInputVectorData, class TOutputVectorData>

--- a/Modules/Fusion/MajorityVoting/test/otbNeighborhoodMajorityVotingImageFilterTest.cxx
+++ b/Modules/Fusion/MajorityVoting/test/otbNeighborhoodMajorityVotingImageFilterTest.cxx
@@ -28,8 +28,6 @@
 
 #include "otbNeighborhoodMajorityVotingImageFilter.h"
 
-#include "itkTimeProbe.h"
-
 
 int otbNeighborhoodMajorityVotingImageFilterTest(int argc, char* argv[])
 {
@@ -160,7 +158,7 @@ int otbNeighborhoodMajorityVotingImageFilterIsolatedTest(int itkNotUsed(argc), c
 
 
   NeighMajVotingFilter->SetKeepOriginalLabelBool(true);
-    
+
   rad[0] = 1;
   rad[1] = 1;
   NeighMajVotingFilter->SetLabelForNoDataPixels(10);

--- a/Modules/IO/IOGDAL/src/otbGDALImageIO.cxx
+++ b/Modules/IO/IOGDAL/src/otbGDALImageIO.cxx
@@ -25,6 +25,7 @@
 #include "otbGDALImageIO.h"
 #include "otbMacro.h"
 #include "otbSystem.h"
+#include "otbStopwatch.h"
 #include "itksys/SystemTools.hxx"
 #include "otbImage.h"
 #include "otb_tinyxml.h"
@@ -35,7 +36,6 @@
 
 #include "itkRGBPixel.h"
 #include "itkRGBAPixel.h"
-#include "itkTimeProbe.h"
 
 #include "cpl_conv.h"
 #include "ogr_spatialref.h"
@@ -408,8 +408,7 @@ void GDALImageIO::Read(void* buffer)
                    << " lineOffset = " << lineOffset << "\n"
                    << " bandOffset = " << bandOffset );
 
-    itk::TimeProbe chrono;
-    chrono.Start();
+    otb::Stopwatch chrono = otb::Stopwatch::StartNew();
     CPLErr lCrGdal = m_Dataset->GetDataSet()->RasterIO(GF_Read,
                                                        lFirstColumn,
                                                        lFirstLine,
@@ -426,7 +425,7 @@ void GDALImageIO::Read(void* buffer)
                                                        lineOffset,
                                                        bandOffset);
     chrono.Stop();
-    otbMsgDevMacro(<< "RasterIO Read took " << chrono.GetTotal() << " sec")
+    otbMsgDevMacro(<< "RasterIO Read took " << chrono.GetElapsedMilliseconds() << " ms")
 
     // Check if gdal call succeed
     if (lCrGdal == CE_Failure)
@@ -1211,7 +1210,7 @@ void GDALImageIO::InternalReadImageInformation()
       // automatically read as a color image (using the palette). Perhaps this
       // behaviour should be restricted.  Comment color table interpretation in
       // gdalimageio
-  
+
       // FIXME: Better support of color table in OTB
       // - disable palette conversion in GDALImageIO (the comments in this part
       // of the code are rather careful)
@@ -1219,7 +1218,7 @@ void GDALImageIO::InternalReadImageInformation()
       // a kind of LUT ?).
       // - ImageFileReader should use a kind of adapter filter to convert the mono
       // image into color.
-      
+
       // Do not set indexed image attribute to true
       //m_IsIndexed = true;
 
@@ -1387,8 +1386,7 @@ void GDALImageIO::Write(const void* buffer)
                  "\n, Line offset =" << m_BytePerPixel * m_NbBands * lNbColumns << // is pixelOffset * nbColumns
                  "\n, Band offset =" <<  m_BytePerPixel) //  is BytePerPixel
 
-                 itk::TimeProbe chrono;
-    chrono.Start();
+    otb::Stopwatch chrono = otb::Stopwatch::StartNew();
     CPLErr lCrGdal = m_Dataset->GetDataSet()->RasterIO(GF_Write,
                                                        lFirstColumn,
                                                        lFirstLine,
@@ -1410,7 +1408,7 @@ void GDALImageIO::Write(const void* buffer)
                                                        // Band offset is BytePerPixel
                                                        m_BytePerPixel);
     chrono.Stop();
-    otbMsgDevMacro(<< "RasterIO Write took " << chrono.GetTotal() << " sec")
+    otbMsgDevMacro(<< "RasterIO Write took " << chrono.GetElapsedMilliseconds() << " ms")
 
     // Check if writing succeed
     if (lCrGdal == CE_Failure)

--- a/Modules/IO/IOGDAL/src/otbOGRIOHelper.cxx
+++ b/Modules/IO/IOGDAL/src/otbOGRIOHelper.cxx
@@ -23,7 +23,7 @@
 #include "otbMacro.h"
 #include "ogrsf_frmts.h"
 #include "otbOGR.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 namespace otb
 {
@@ -188,11 +188,10 @@ void OGRIOHelper
   layer->ResetReading();
 
   unsigned int   counter = 0;
-  itk::TimeProbe chrono;
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
 
   while ((feature = layer->GetNextFeature()) != ITK_NULLPTR)
     {
-    chrono.Start();
 
     // A pointer to the current multi-geometry
     InternalTreeNodeType::Pointer multiPtr;
@@ -203,7 +202,6 @@ void OGRIOHelper
     if (geometry == ITK_NULLPTR)
       {
       OGRFeature::DestroyFeature(feature);
-      chrono.Stop();
       ++counter;
       continue;
       }
@@ -642,11 +640,12 @@ void OGRIOHelper
 
 
     OGRFeature::DestroyFeature(feature);
-    chrono.Stop();
     ++counter;
     } //end While feature
+
+  chrono.Stop();
   otbMsgDevMacro(
-    << layer->GetFeatureCount() << " features read, average insertion time " << chrono.GetMean() << " s");
+    << layer->GetFeatureCount() << " features read, total processing time " << chrono.GetElapsedMilliseconds() << " ms");
 }
 
 

--- a/Modules/IO/IOGDAL/src/otbOGRVectorDataIO.cxx
+++ b/Modules/IO/IOGDAL/src/otbOGRVectorDataIO.cxx
@@ -27,7 +27,7 @@
 #include "otbMacro.h"
 #include "otbDataNode.h"
 #include "otbMetaDataKey.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "otbOGRIOHelper.h"
 
 namespace otb
@@ -204,8 +204,7 @@ bool OGRVectorDataIO::CanWriteFile(const char* filename) const
 
 void OGRVectorDataIO::Write(const itk::DataObject* datag, char ** /** unused */)
 {
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
 
   VectorDataConstPointerType data = dynamic_cast<const VectorDataType*>(datag);
 
@@ -298,7 +297,7 @@ void OGRVectorDataIO::Write(const itk::DataObject* datag, char ** /** unused */)
     }
 
   chrono.Stop();
-  otbMsgDevMacro( << "OGRVectorDataIO: file saved in " << chrono.GetMean() << " seconds. (" << layerKept <<
+  otbMsgDevMacro( << "OGRVectorDataIO: file saved in " << chrono.GetElapsedMilliseconds() << " ms. (" << layerKept <<
   " elements)" );
 
   otbMsgDevMacro(<< " OGRVectorDataIO::Write()  ");

--- a/Modules/IO/IOKML/src/otbKMLVectorDataIO.cxx
+++ b/Modules/IO/IOKML/src/otbKMLVectorDataIO.cxx
@@ -38,7 +38,7 @@
 #include "otbDataNode.h"
 #include "itkPreOrderTreeIterator.h"
 #include "otbMetaDataKey.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 
 namespace otb
@@ -525,8 +525,7 @@ bool KMLVectorDataIO::CanWriteFile(const char* filename) const
 
 void KMLVectorDataIO::Write(const itk::DataObject* datag, char ** itkNotUsed(papszOptions))
 {
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   // Retrieve data required for georeferencing
 
   VectorDataConstPointerType data_in = dynamic_cast<const VectorDataType*>(datag);
@@ -600,7 +599,7 @@ void KMLVectorDataIO::Write(const itk::DataObject* datag, char ** itkNotUsed(pap
   //std::cout << xml;
 
   chrono.Stop();
-  otbMsgDevMacro(<< "KMLVectorDataIO: file saved in " << chrono.GetMean() << " seconds. (" << m_Kept << " elements)" );
+  otbMsgDevMacro(<< "KMLVectorDataIO: file saved in " << chrono.GetElapsedMilliseconds() << " ms. (" << m_Kept << " elements)" );
   otbMsgDevMacro(<< " KMLVectorDataIO::Write()  ");
 
 }

--- a/Modules/IO/IOTileMap/src/otbTileMapImageIO.cxx
+++ b/Modules/IO/IOTileMap/src/otbTileMapImageIO.cxx
@@ -33,7 +33,6 @@
 
 #include "otbGDALImageIO.h"
 
-#include "itkTimeProbe.h"
 #include "otbCurlHelper.h"
 
 #include "otbImageKeywordlist.h"
@@ -514,7 +513,7 @@ void TileMapImageIO::ReadImageInformation()
   this->SetNumberOfDimensions(2);
   this->SetFileTypeToBinary();
   this->SetComponentType(UCHAR);
-  
+
   ImageKeywordlist otb_kwl;
   itk::MetaDataDictionary& dict = this->GetMetaDataDictionary();
   itk::ExposeMetaData<ImageKeywordlist>(dict,

--- a/Modules/Learning/Sampling/include/otbOGRDataToSamplePositionFilter.txx
+++ b/Modules/Learning/Sampling/include/otbOGRDataToSamplePositionFilter.txx
@@ -22,7 +22,6 @@
 #define otbOGRDataToSamplePositionFilter_txx
 
 #include "otbOGRDataToSamplePositionFilter.h"
-#include "itkTimeProbe.h"
 
 namespace otb
 {
@@ -272,7 +271,7 @@ PersistentOGRDataToSamplePositionFilter<TInputImage,TMaskImage,TSampler>
   typedef std::vector<unsigned long> LoadVectorType;
   LoadVectorType currentLoad;
   currentLoad.resize(numberOfThreads, 0UL);
-  
+
   ClassCountMapType::iterator largestClass;
   unsigned long minLoad;
   unsigned int destThread;

--- a/Modules/Learning/Sampling/include/otbPersistentSamplingFilterBase.txx
+++ b/Modules/Learning/Sampling/include/otbPersistentSamplingFilterBase.txx
@@ -26,7 +26,7 @@
 #include "itkImageRegionConstIteratorWithOnlyIndex.h"
 #include "itkImageRegionConstIterator.h"
 #include "otbMacro.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "itkProgressReporter.h"
 
 namespace otb
@@ -36,7 +36,7 @@ template<class TInputImage, class TMaskImage>
 PersistentSamplingFilterBase<TInputImage,TMaskImage>
 ::PersistentSamplingFilterBase()
   : m_FieldName(std::string("class"))
-  , m_FieldIndex(0)  
+  , m_FieldIndex(0)
   , m_LayerIndex(0)
   , m_OutLayerName(std::string("output"))
   , m_OGRLayerCreationOptions()
@@ -276,11 +276,10 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
   this->m_InMemoryInputs.clear();
 
   unsigned int numberOfThreads = this->GetNumberOfThreads();
-  
+
   // gather temporary outputs and write to output
   const otb::ogr::DataSource* vectors = this->GetOGRData();
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   unsigned int count = 0;
   for (unsigned int k=0 ; k < this->GetNumberOfOutputs() ; k++)
     {
@@ -297,7 +296,7 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
         {
         itkExceptionMacro(<< "Unable to start transaction for OGR layer " << outLayer.ogr().GetName() << ".");
         }
-  
+
       for (unsigned int thread=0 ; thread < numberOfThreads ; thread++)
         {
         ogr::Layer inLayer = this->m_InMemoryOutputs[thread][count]->GetLayerChecked(0);
@@ -305,7 +304,7 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
           {
           continue;
           }
-  
+
         ogr::Layer::const_iterator tmpIt = inLayer.begin();
         // This test only uses 1 input, not compatible with multiple OGRData inputs
         if (vectors == realOutput)
@@ -327,7 +326,7 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
             }
           }
         }
-  
+
       err = outLayer.ogr().CommitTransaction();
       if (err != OGRERR_NONE)
         {
@@ -336,8 +335,9 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
       count++;
       }
     }
+
   chrono.Stop();
-  otbMsgDebugMacro(<< "write ogr points took " << chrono.GetTotal() << " sec");
+  otbMsgDebugMacro(<< "Writing OGR points took " << chrono.GetElapsedMilliseconds() << " ms");
   this->m_InMemoryOutputs.clear();
 }
 
@@ -380,7 +380,7 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
 {
   typename TInputImage::PointType imgPoint;
   typename TInputImage::IndexType imgIndex;
-  
+
   switch (geom->getGeometryType())
     {
     case wkbPoint:
@@ -388,11 +388,11 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
       {
       OGRPoint* castPoint = dynamic_cast<OGRPoint*>(geom);
       if (castPoint == ITK_NULLPTR) break;
-      
+
       imgPoint[0] = castPoint->getX();
       imgPoint[1] = castPoint->getY();
       const TInputImage* img = this->GetInput();
-      const TMaskImage* mask = this->GetMask(); 
+      const TMaskImage* mask = this->GetMask();
       img->TransformPhysicalPointToIndex(imgPoint,imgIndex);
       if ((mask == ITK_NULLPTR) || mask->GetPixel(imgIndex))
         {
@@ -569,7 +569,7 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
         }
       ++it;
       }
-    }  
+    }
 }
 
 template <class TInputImage, class TMaskImage>
@@ -757,14 +757,14 @@ PersistentSamplingFilterBase<TInputImage,TMaskImage>
 {
   TInputImage *inputImage = const_cast<TInputImage*>(this->GetInput());
   inputImage->UpdateOutputInformation();
-  
+
   ogr::Layer inLayer = inputDS->GetLayer(this->GetLayerIndex());
 
   bool updateMode = false;
   if (inputDS == outputDS)
     {
     updateMode = true;
-    // Check m_OutLayerName is same as input layer name 
+    // Check m_OutLayerName is same as input layer name
     m_OutLayerName = inLayer.GetName();
     }
 

--- a/Modules/MPI/MPITiffWriter/include/otbSimpleParallelTiffWriter.h
+++ b/Modules/MPI/MPITiffWriter/include/otbSimpleParallelTiffWriter.h
@@ -28,10 +28,6 @@
 #include "otbExtendedFilenameToWriterOptions.h"
 #include "otbMPIConfig.h"
 
-// Time probe
-#include "itkTimeProbe.h"
-
-
 #include "itkImageFileWriter.h"
 
 #include "itkObjectFactoryBase.h"

--- a/Modules/MPI/MPITiffWriter/include/otbSimpleParallelTiffWriter.txx
+++ b/Modules/MPI/MPITiffWriter/include/otbSimpleParallelTiffWriter.txx
@@ -22,7 +22,7 @@
 #define otbSimpleParallelTiffWriter_txx
 
 #include "otbSimpleParallelTiffWriter.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 
 using std::vector;
 
@@ -617,7 +617,7 @@ SimpleParallelTiffWriter<TInputImage>
    ************************************************************************/
 
   // Time probe for overall process time
-  itk::TimeProbe overallTime;
+  otb::Stopwatch overallTime;
   overallTime.Start();
 
   // Check that streaming is relevant
@@ -674,19 +674,16 @@ SimpleParallelTiffWriter<TInputImage>
       /*
        * Processing
        */
-      itk::TimeProbe processingTime;
-      processingTime.Start();
+      otb::Stopwatch processingTime = otb::Stopwatch::StartNew();
       inputPtr->SetRequestedRegion(streamRegion);
       inputPtr->PropagateRequestedRegion();
       inputPtr->UpdateOutputData();
-      processingTime.Stop();
-      processDuration += processingTime.GetTotal();
+      processDuration += processingTime.GetElapsedMilliseconds();
 
       /*
        * Writing using SPTW
        */
-      itk::TimeProbe writingTime;
-      writingTime.Start();
+      otb::Stopwatch writingTime = otb::Stopwatch::StartNew();
       if (!m_VirtualMode)
         {
         sptw::write_area(output_raster,
@@ -696,8 +693,7 @@ SimpleParallelTiffWriter<TInputImage>
             streamRegion.GetIndex()[0] + streamRegion.GetSize()[0] -1,
             streamRegion.GetIndex()[1] + streamRegion.GetSize()[1] -1);
         }
-      writingTime.Stop();
-      writeDuration += writingTime.GetTotal();
+      writeDuration += writingTime.GetElapsedMilliseconds();
       numberOfProcessedRegions += 1;
       }
     }
@@ -731,12 +727,12 @@ SimpleParallelTiffWriter<TInputImage>
       itkDebugMacro( "Process Id\tProcessing\tWriting" );
 	  for (unsigned int i = 0; i < process_runtimes.size(); i+=nValues)
 	    {
-      itkDebugMacro( <<(int (i/nValues)) << 
+      itkDebugMacro( <<(int (i/nValues)) <<
 	        "\t" << process_runtimes[i] <<
 	        "\t" << process_runtimes[i+1] <<
 	        "\t("<< process_runtimes[i+2] << " regions)" );
 	    }
-	  itkDebugMacro( "Overall time:" << overallTime.GetTotal() );
+	  itkDebugMacro( "Overall time: " << overallTime.GetElapsedMilliseconds() / 1000 << " s" );
 	  }
    */
 

--- a/Modules/Registration/DisparityMap/test/otbFineRegistrationImageFilterTest.cxx
+++ b/Modules/Registration/DisparityMap/test/otbFineRegistrationImageFilterTest.cxx
@@ -25,7 +25,7 @@
 #include "otbImageFileWriter.h"
 #include "otbFineRegistrationImageFilter.h"
 #include "otbStandardFilterWatcher.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "otbExtractROI.h"
 
 
@@ -154,11 +154,10 @@ int otbFineRegistrationImageFilterTest( int argc, char * argv[] )
   }
 
   //otb::StandardFilterWatcher watcher(registration,"Registration");
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   registration->Update();
-  chrono.Stop();
-  std::cout<<chrono.GetMean()<<"\t";
+
+  std::cout << "Processing time was " << chrono.GetElapsedMilliseconds() << " ms\n";
 
   CorrelWriterType::Pointer correlWriter = CorrelWriterType::New();
   correlWriter->SetFileName(correlFileName);

--- a/Modules/Segmentation/Conversion/include/otbPersistentImageToOGRDataFilter.txx
+++ b/Modules/Segmentation/Conversion/include/otbPersistentImageToOGRDataFilter.txx
@@ -23,7 +23,7 @@
 #define otbPersistentImageToOGRDataFilter_txx
 
 #include "otbPersistentImageToOGRDataFilter.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include <boost/foreach.hpp>
 #include <stdio.h>
 #include "otbMacro.h"
@@ -166,11 +166,9 @@ PersistentImageToOGRDataFilter<TImage>
 
 
   //Copy features contained in the memory layer (srcLayer) in the output layer
-  itk::TimeProbe chrono;
-  chrono.Start();
-  
-  OGRErr err = dstLayer.ogr().StartTransaction();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
 
+  OGRErr err = dstLayer.ogr().StartTransaction();
   if (err != OGRERR_NONE)
     {
     itkExceptionMacro(<< "Unable to start transaction for OGR layer " << dstLayer.ogr().GetName() << ".");
@@ -192,7 +190,7 @@ PersistentImageToOGRDataFilter<TImage>
     }
 
   chrono.Stop();
-  otbMsgDebugMacro(<< "write ogr tile took " << chrono.GetTotal() << " sec");
+  otbMsgDebugMacro(<< "Writing OGR tile took " << chrono.GetElapsedMilliseconds() << " ms");
 }
 
 template<class TImage>

--- a/Modules/Segmentation/Conversion/include/otbPersistentImageToOGRLayerFilter.txx
+++ b/Modules/Segmentation/Conversion/include/otbPersistentImageToOGRLayerFilter.txx
@@ -23,7 +23,7 @@
 #define otbPersistentImageToOGRLayerFilter_txx
 
 #include "otbPersistentImageToOGRLayerFilter.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include <boost/foreach.hpp>
 #include <stdio.h>
 #include "otbMacro.h"
@@ -143,11 +143,9 @@ PersistentImageToOGRLayerFilter<TImage>
      }
 
   //Copy features contained in the memory layer (srcLayer) in the output layer
-  itk::TimeProbe chrono;
-  chrono.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
 
   OGRErr err = m_OGRLayer.ogr().StartTransaction();
-
   if (err != OGRERR_NONE)
     {
     itkExceptionMacro(<< "Unable to start transaction for OGR layer " << m_OGRLayer.ogr().GetName() << ".");
@@ -162,14 +160,14 @@ PersistentImageToOGRLayerFilter<TImage>
     }
 
   err = m_OGRLayer.ogr().CommitTransaction();
-  
+
   if (err != OGRERR_NONE)
     {
     itkExceptionMacro(<< "Unable to commit transaction for OGR layer " << m_OGRLayer.ogr().GetName() << ".");
     }
 
   chrono.Stop();
-  otbMsgDebugMacro(<< "write ogr tile took " << chrono.GetTotal() << " sec");
+  otbMsgDebugMacro(<< "Writing OGR tile took " << chrono.GetElapsedMilliseconds() << " ms");
 
 }
 

--- a/Modules/Segmentation/Conversion/test/otbVectorDataToLabelMapFilter.cxx
+++ b/Modules/Segmentation/Conversion/test/otbVectorDataToLabelMapFilter.cxx
@@ -20,7 +20,6 @@
 
 #include "itkLabelMapToLabelImageFilter.h"
 
-#include "itkTimeProbe.h"
 #include "otbMacro.h"
 #include "otbImage.h"
 //#include "otbImageFileReader.h"

--- a/Modules/Segmentation/OGRProcessing/include/otbOGRLayerStreamStitchingFilter.txx
+++ b/Modules/Segmentation/OGRProcessing/include/otbOGRLayerStreamStitchingFilter.txx
@@ -26,7 +26,6 @@
 
 #include <iomanip>
 #include "ogrsf_frmts.h"
-#include "itkTimeProbe.h"
 #include <set>
 
 namespace otb
@@ -363,7 +362,7 @@ OGRLayerStreamStitchingFilter<TInputImage>
 
       if(m_OGRLayer.ogr().TestCapability("Transactions"))
         {
-      
+
         OGRErr errCommitX = m_OGRLayer.ogr().CommitTransaction();
         if (errCommitX != OGRERR_NONE)
           {
@@ -371,11 +370,11 @@ OGRLayerStreamStitchingFilter<TInputImage>
           }
         }
    } //end for y
-      
+
    if(m_OGRLayer.ogr().TestCapability("Transactions"))
      {
      const OGRErr errCommitY = m_OGRLayer.ogr().CommitTransaction();
-     
+
      if (errCommitY != OGRERR_NONE)
        {
        itkWarningMacro(<< "Unable to commit transaction for OGR layer " << m_OGRLayer.ogr().GetName() << ". Gdal error code " << errCommitY << "." << std::endl);

--- a/Modules/Segmentation/OGRProcessing/include/otbStreamingImageToOGRLayerSegmentationFilter.txx
+++ b/Modules/Segmentation/OGRProcessing/include/otbStreamingImageToOGRLayerSegmentationFilter.txx
@@ -27,7 +27,7 @@
 #include "otbVectorDataTransformFilter.h"
 #include "itkAffineTransform.h"
 
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "otbMacro.h"
 #include <cassert>
 
@@ -76,8 +76,6 @@ PersistentImageToOGRLayerSegmentationFilter<TImageType, TSegmentationFilter>
 {
   otbMsgDebugMacro(<< "tile number : " << m_TileNumber);
   ++m_TileNumber;
-  itk::TimeProbe tileChrono;
-  tileChrono.Start();
 
   // Apply an ExtractImageFilter to avoid problems with filters asking for the LargestPossibleRegion
   typedef itk::ExtractImageFilter<InputImageType, InputImageType> ExtractImageFilterType;
@@ -94,16 +92,13 @@ PersistentImageToOGRLayerSegmentationFilter<TImageType, TSegmentationFilter>
   typename LabelImageToOGRDataSourceFilterType::Pointer labelImageToOGRDataFilter =
                                               LabelImageToOGRDataSourceFilterType::New();
 
-  itk::TimeProbe chrono1;
-  chrono1.Start();
+  otb::Stopwatch chrono = otb::Stopwatch::StartNew();
   m_SegmentationFilter->SetInput(extract->GetOutput());
   m_SegmentationFilter->UpdateLargestPossibleRegion();
 
-  chrono1.Stop();
-  otbMsgDebugMacro(<<"segmentation took " << chrono1.GetTotal() << " sec");
+  otbMsgDebugMacro(<<"segmentation took " << chrono.GetElapsedMilliseconds() / 1000 << " sec");
 
-  itk::TimeProbe chrono2;
-  chrono2.Start();
+  chrono.Restart();
   typename LabelImageType::ConstPointer inputMask = this->GetInputMask();
   if (!inputMask.IsNull())
   {
@@ -124,12 +119,10 @@ PersistentImageToOGRLayerSegmentationFilter<TImageType, TSegmentationFilter>
   labelImageToOGRDataFilter->SetUse8Connected(m_Use8Connected);
   labelImageToOGRDataFilter->Update();
 
-  chrono2.Stop();
-  otbMsgDebugMacro(<< "vectorization took " << chrono2.GetTotal() << " sec");
+  otbMsgDebugMacro(<< "vectorization took " << chrono.GetElapsedMilliseconds() / 1000 << " sec");
 
   //Relabeling & simplication of geometries & filtering small objects
-  itk::TimeProbe chrono3;
-  chrono3.Start();
+  chrono.Restart();
   OGRDataSourcePointerType tmpDS = const_cast<OGRDataSourceType *>(labelImageToOGRDataFilter->GetOutput());
   OGRLayerType tmpLayer = tmpDS->GetLayer(0);
 
@@ -169,8 +162,8 @@ PersistentImageToOGRLayerSegmentationFilter<TImageType, TSegmentationFilter>
         }
      }
   }
-  chrono3.Stop();
-  otbMsgDebugMacro(<< "relabeling, filtering small objects and simplifying geometries took " << chrono3.GetTotal() << " sec");
+  chrono.Stop();
+  otbMsgDebugMacro(<< "relabeling, filtering small objects and simplifying geometries took " << chrono.GetElapsedMilliseconds() / 1000 << " sec");
 
   return tmpDS;
 }

--- a/Modules/Wrappers/ApplicationEngine/include/otbWrapperApplication.h
+++ b/Modules/Wrappers/ApplicationEngine/include/otbWrapperApplication.h
@@ -27,7 +27,7 @@
 #include "otbWrapperParameterGroup.h"
 
 #include "otbLogger.h"
-#include "itkTimeProbe.h"
+#include "otbStopwatch.h"
 #include "otbWrapperMacros.h"
 #include "otbWrapperInputImageParameter.h"
 #include "otbWrapperInputImageListParameter.h"
@@ -1016,7 +1016,7 @@ private:
   std::string m_Doclink;
 
   /** Chrono to measure execution time */
-  itk::TimeProbe m_Chrono;
+  otb::Stopwatch m_Chrono;
 
   //rashad:: controls adding of -xml parameter. set to true by default
   bool                              m_HaveInXML;

--- a/Modules/Wrappers/ApplicationEngine/src/otbWrapperApplication.cxx
+++ b/Modules/Wrappers/ApplicationEngine/src/otbWrapperApplication.cxx
@@ -410,8 +410,7 @@ int Application::Execute()
 
 int Application::ExecuteAndWriteOutput()
 {
-  m_Chrono.Reset();
-  m_Chrono.Start();
+  m_Chrono.Restart();
 
   int status = this->Execute();
 
@@ -1701,7 +1700,7 @@ std::string Application::GetProgressDescription() const
 
 double Application::GetLastExecutionTiming() const
 {
-  return m_Chrono.GetTotal();
+  return m_Chrono.GetElapsedMilliseconds() / 1000.0;
 }
 
 }


### PR DESCRIPTION
Basically, the `itk::TimeProbe` instance in `GDALImageIO` sometimes shows up in the profiles. Here is a summary of the changes:

- The first commit adds an `otb::Stopwatch` class which uses `std::chrono::steady_clock`. Its API is heavily inspired from .NET's Stopwatch. It doesn't have `itk::TimeProbe`'s feature of keeping a sample list and doesn't compute the mean time and iteration count.
- The second commit replaces `TimeProbe` with `Stopwatch`, the changes are mostly mechanical, with a couple of exceptions:
    * Some places used `GetMean` instead of `GetTotal` even if the `TimeProbe` was only started once
    * The stopwatch doesn't have to be stopped to get the elapsed time, but I left in `Stop()` calls in some places to avoid compiler warnings under Release configurations
    * Most of the changed code is in `otbMsgDevMacro` calls or in test applications
    * I changed the unit in a couple of places, e.g. `GDALImageIO::{Read,Write}` printed seconds, while milliseconds are probably more appropriate for those operations
    * I changed the value from the average to the total in a couple of places, e.g. `OGRIOHelper::ConvertOGRLayerToDataTreeNode` which displayed the total number of features and the average time and now shows the total time
    * Some operations stopped and restarted the timer, but I made it wrap the whole processing, e.g. `OGRIOHelper::ConvertOGRLayerToDataTreeNode` or `otbLabelObjectMapVectorizer.cxx`
    * I made a couple of indentation fixes / changes where it was misleading

Compile tested under `RelWithDebInfo`.