### PR TITLE
ENH: add 3d image support to StreamingManager and PipelineMemoryPrint…

### DIFF
--- a/Modules/Core/Streaming/include/otbStreamingManager.hxx
+++ b/Modules/Core/Streaming/include/otbStreamingManager.hxx
@@ -89,17 +89,24 @@ unsigned int StreamingManager<TImage>::EstimateOptimalNumberOfDivisions(itk::Dat
     // Define a small region to run the memory footprint estimation,
     // around the image center, 100 pixels wide in each dimension
     SizeType smallSize;
-    smallSize.Fill(100);
     IndexType index;
-    index[0] = region.GetIndex()[0] + region.GetSize()[0] / 2 - 50;
-    index[1] = region.GetIndex()[1] + region.GetSize()[1] / 2 - 50;
+    for (int d=0; d < ImageDimension; ++d)
+    {
+        if (region.GetSize()[d] < 100)
+        {
+            index[d] = 0;
+            smallSize[d] = region.GetSize()[d];
+        }
+        else
+        {
+            index[d] = region.GetIndex()[d] + region.GetSize()[d] / 2 - 50;
+            smallSize[d] = 100;
+        }
+    }
 
     RegionType smallRegion;
     smallRegion.SetSize(smallSize);
     smallRegion.SetIndex(index);
-
-    // In case the image is smaller than 100 pixels in a direction
-    smallRegion.Crop(region);
 
     extractFilter->SetExtractionRegion(smallRegion);
 

--- a/Modules/Core/Streaming/src/otbPipelineMemoryPrintCalculator.cxx
+++ b/Modules/Core/Streaming/src/otbPipelineMemoryPrintCalculator.cxx
@@ -193,6 +193,42 @@ PipelineMemoryPrintCalculator::MemoryPrintType PipelineMemoryPrintCalculator::Ev
         print += this->EvaluateDataObjectPrint(it.Get());                                                           \
     }                                                                                                               \
     return print;                                                                                                   \
+  }                                                                                                                 \
+  if (dynamic_cast<itk::Image<type, 3>*>(data) != NULL)                                                             \
+  {                                                                                                                 \
+    itk::Image<type, 3>* image = dynamic_cast<itk::Image<type, 3>*>(data);                                          \
+    return image->GetRequestedRegion().GetNumberOfPixels() * image->GetNumberOfComponentsPerPixel() * sizeof(type); \
+  }                                                                                                                 \
+  if (dynamic_cast<itk::VectorImage<type, 3>*>(data) != NULL)                                                       \
+  {                                                                                                                 \
+    itk::VectorImage<type, 3>* image = dynamic_cast<itk::VectorImage<type, 3>*>(data);                              \
+    return image->GetRequestedRegion().GetNumberOfPixels() * image->GetNumberOfComponentsPerPixel() * sizeof(type); \
+  }                                                                                                                 \
+  if (dynamic_cast<ImageList<Image<type, 3>>*>(data) != NULL)                                                       \
+  {                                                                                                                 \
+    ImageList<Image<type, 3>>* imageList = dynamic_cast<otb::ImageList<otb::Image<type, 3>>*>(data);                \
+    MemoryPrintType print(0);                                                                                       \
+    for (ImageList<Image<type, 3>>::Iterator it = imageList->Begin(); it != imageList->End(); ++it)                 \
+    {                                                                                                               \
+      if (it.Get()->GetSource())                                                                                    \
+        print += this->EvaluateProcessObjectPrintRecursive(it.Get()->GetSource());                                  \
+      else                                                                                                          \
+        print += this->EvaluateDataObjectPrint(it.Get());                                                           \
+    }                                                                                                               \
+    return print;                                                                                                   \
+  }                                                                                                                 \
+  if (dynamic_cast<ImageList<VectorImage<type, 3>>*>(data) != NULL)                                                 \
+  {                                                                                                                 \
+    ImageList<VectorImage<type, 3>>* imageList = dynamic_cast<otb::ImageList<otb::VectorImage<type, 3>>*>(data);    \
+    MemoryPrintType print(0);                                                                                       \
+    for (ImageList<VectorImage<type, 3>>::ConstIterator it = imageList->Begin(); it != imageList->End(); ++it)      \
+    {                                                                                                               \
+      if (it.Get()->GetSource())                                                                                    \
+        print += this->EvaluateProcessObjectPrintRecursive(it.Get()->GetSource());                                  \
+      else                                                                                                          \
+        print += this->EvaluateDataObjectPrint(it.Get());                                                           \
+    }                                                                                                               \
+    return print;                                                                                                   \
   }
 
 


### PR DESCRIPTION
…Calculator

## Summary

Add nD image support to `otbStreamingManager` and 3D image support to `PipelineMemoryPrintCalculator`

## Rationale

The `StreamingManager` class defines a small, i.e. 100 pixel, region around the image centre that is used to estimate the memory footprint of the processing pipeline. The current implementation only explicitly sets the index for dimensions `0` and `1` respectively. Since the index value assignment does not account for the actual number of dimensions of the image, a `1D` image would produce a segmentation fault when the value of `index[1]` is assigned. 

The `PipelineMemoryPrintCalculator` currently only supports `2D` images. The number of image dimensions is currently hard coded in `::EvaluateDataObjectPrint` in macro `OTB_IMAGE_SIZE_BLOCK`. 

## Implementation Details

**otbStreamingManager.hxx**

- The assignment of index and size values of the test region is done considering the actual number of image dimensions. 
- `smallRegion.Crop(region)` is removed because it is superfluous with the new implementation. 

**otbPipelineMemoryPrintCalculator.cxx**

- I added a set of image memory print calculation statements for 3-dimensional images to the `OTB_IMAGE_SIZE_BLOCK` macro
- *Note*: This revision will be performance neutral for 2D images but enables use of this class for 3D images. A future improvement of this class would be to template it over the image type to enable nD support. 

## Copyright

The copyright owner is Manaaki Whenua - Landcare Research (MWLR). MWLR has signed the ORFEO ToolBox Contributor License Agreement. 